### PR TITLE
fix: Add cookie proxy headers to Nginx reverse proxy

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -25,5 +25,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_redirect off;
+        
+        # Proxy cookie headers for session support
+        proxy_pass_header Set-Cookie;
+        proxy_cookie_path / /;
+        proxy_cookie_domain web:8000 localhost;
     }
 }


### PR DESCRIPTION
Fixes session cookie issues with Nginx reverse proxy (#157)

## Changes
- Added  to pass session cookies through
- Added  to preserve cookie paths  
- Added  to rewrite cookie domain from backend to frontend

## Issue
Sessions were not persisting after introducing Nginx as reverse proxy because cookies weren't being properly forwarded.